### PR TITLE
feat(porch): keep default YAML; add tests; optional SMP output

### DIFF
--- a/cmd/porch-publisher/main_test.go
+++ b/cmd/porch-publisher/main_test.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+func TestMainIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	
+	// Create temp directory for test files
+	tmpDir := t.TempDir()
+	
+	// Create test intent file
+	intent := Intent{
+		IntentType: "scaling",
+		Target:     "test-app",
+		Namespace:  "test-namespace",
+		Replicas:   3,
+	}
+	
+	intentJSON, err := json.Marshal(intent)
+	if err != nil {
+		t.Fatalf("Failed to marshal intent: %v", err)
+	}
+	
+	intentFile := filepath.Join(tmpDir, "test-intent.json")
+	if err := os.WriteFile(intentFile, intentJSON, 0644); err != nil {
+		t.Fatalf("Failed to write intent file: %v", err)
+	}
+	
+	outputDir := filepath.Join(tmpDir, "output")
+	
+	// Test default format (full)
+	t.Run("DefaultFormat", func(t *testing.T) {
+		cmd := exec.Command("go", "run", "main.go", "-intent", intentFile, "-out", outputDir)
+		cmd.Dir = "."
+		output, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("Command failed: %v\nOutput: %s", err, output)
+		}
+		
+		// Check YAML file exists
+		yamlPath := filepath.Join(outputDir, "scaling-patch.yaml")
+		if _, err := os.Stat(yamlPath); os.IsNotExist(err) {
+			t.Error("Expected YAML file not created")
+		}
+		
+		content, _ := os.ReadFile(yamlPath)
+		expected := `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-app
+  namespace: test-namespace
+spec:
+  replicas: 3
+`
+		if string(content) != expected {
+			t.Errorf("Unexpected YAML content:\nGot:\n%s\nExpected:\n%s", content, expected)
+		}
+	})
+	
+	// Test SMP format
+	t.Run("SMPFormat", func(t *testing.T) {
+		outputDirSMP := filepath.Join(tmpDir, "output-smp")
+		cmd := exec.Command("go", "run", "main.go", "-intent", intentFile, "-out", outputDirSMP, "-format", "smp")
+		cmd.Dir = "."
+		output, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("Command failed: %v\nOutput: %s", err, output)
+		}
+		
+		// Check JSON file exists
+		jsonPath := filepath.Join(outputDirSMP, "scaling-patch.json")
+		if _, err := os.Stat(jsonPath); os.IsNotExist(err) {
+			t.Error("Expected JSON file not created")
+		}
+		
+		content, _ := os.ReadFile(jsonPath)
+		var smp map[string]interface{}
+		if err := json.Unmarshal(content, &smp); err != nil {
+			t.Fatalf("Invalid JSON output: %v", err)
+		}
+		
+		// Validate structure
+		if smp["apiVersion"] != "apps/v1" {
+			t.Errorf("Wrong apiVersion: %v", smp["apiVersion"])
+		}
+		if smp["kind"] != "Deployment" {
+			t.Errorf("Wrong kind: %v", smp["kind"])
+		}
+	})
+	
+	// Test invalid intent type
+	t.Run("InvalidIntentType", func(t *testing.T) {
+		invalidIntent := Intent{
+			IntentType: "networking",
+			Target:     "test-app",
+			Namespace:  "test-namespace",
+			Replicas:   3,
+		}
+		
+		invalidJSON, _ := json.Marshal(invalidIntent)
+		invalidFile := filepath.Join(tmpDir, "invalid-intent.json")
+		os.WriteFile(invalidFile, invalidJSON, 0644)
+		
+		cmd := exec.Command("go", "run", "main.go", "-intent", invalidFile, "-out", tmpDir)
+		cmd.Dir = "."
+		output, err := cmd.CombinedOutput()
+		if err == nil {
+			t.Fatal("Expected command to fail for invalid intent type")
+		}
+		
+		if !contains(string(output), "only scaling intent is supported") {
+			t.Errorf("Expected error message about scaling intent, got: %s", output)
+		}
+	})
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(s) > 0 && (s[0:len(substr)] == substr || contains(s[1:], substr)))
+}

--- a/internal/porch/writer.go
+++ b/internal/porch/writer.go
@@ -1,0 +1,84 @@
+package porch
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// WriteIntent writes the intent to the output directory in the specified format
+// format can be "full" (default YAML) or "smp" (Strategic Merge Patch JSON)
+func WriteIntent(intent interface{}, outDir string, format string) error {
+	// Extract fields using JSON tags via marshal/unmarshal
+	data, err := json.Marshal(intent)
+	if err != nil {
+		return fmt.Errorf("failed to marshal intent: %w", err)
+	}
+	
+	var fields struct {
+		IntentType string `json:"intent_type"`
+		Target     string `json:"target"`
+		Namespace  string `json:"namespace"`
+		Replicas   int    `json:"replicas"`
+	}
+	if err := json.Unmarshal(data, &fields); err != nil {
+		return fmt.Errorf("failed to unmarshal intent: %w", err)
+	}
+	
+	// Validate
+	if fields.IntentType != "scaling" {
+		return fmt.Errorf("only scaling intent is supported in MVP")
+	}
+	
+	// Create output directory
+	if err := os.MkdirAll(outDir, 0o755); err != nil {
+		return fmt.Errorf("failed to create output directory: %w", err)
+	}
+	
+	var content []byte
+	var filename string
+	
+	if format == "smp" {
+		// Strategic Merge Patch format (JSON)
+		smp := map[string]interface{}{
+			"apiVersion": "apps/v1",
+			"kind":       "Deployment",
+			"metadata": map[string]string{
+				"name":      fields.Target,
+				"namespace": fields.Namespace,
+			},
+			"spec": map[string]int{
+				"replicas": fields.Replicas,
+			},
+		}
+		content, err = json.MarshalIndent(smp, "", "  ")
+		if err != nil {
+			return fmt.Errorf("failed to marshal SMP: %w", err)
+		}
+		filename = "scaling-patch.json"
+	} else {
+		// Full manifest format (YAML) - default
+		yaml := fmt.Sprintf(`apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: %s
+  namespace: %s
+spec:
+  replicas: %d
+`, fields.Target, fields.Namespace, fields.Replicas)
+		content = []byte(yaml)
+		filename = "scaling-patch.yaml"
+	}
+	
+	// Write file
+	dst := filepath.Join(outDir, filename)
+	if err := os.WriteFile(dst, content, 0o644); err != nil {
+		return fmt.Errorf("failed to write file: %w", err)
+	}
+	
+	fmt.Println("wrote:", dst)
+	fmt.Println("next: (optional) kpt live init/apply under", outDir)
+	
+	return nil
+}

--- a/internal/porch/writer_test.go
+++ b/internal/porch/writer_test.go
@@ -1,0 +1,144 @@
+package porch
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+type testIntent struct {
+	IntentType string `json:"intent_type"`
+	Target     string `json:"target"`
+	Namespace  string `json:"namespace"`
+	Replicas   int    `json:"replicas"`
+}
+
+func TestWriteIntent_FullFormat(t *testing.T) {
+	tmpDir := t.TempDir()
+	
+	intent := testIntent{
+		IntentType: "scaling",
+		Target:     "my-app",
+		Namespace:  "default",
+		Replicas:   3,
+	}
+	
+	err := WriteIntent(intent, tmpDir, "full")
+	if err != nil {
+		t.Fatalf("WriteIntent failed: %v", err)
+	}
+	
+	// Check file was created
+	yamlPath := filepath.Join(tmpDir, "scaling-patch.yaml")
+	content, err := os.ReadFile(yamlPath)
+	if err != nil {
+		t.Fatalf("Failed to read output file: %v", err)
+	}
+	
+	expected := `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-app
+  namespace: default
+spec:
+  replicas: 3
+`
+	if string(content) != expected {
+		t.Errorf("Unexpected content:\nGot:\n%s\nExpected:\n%s", content, expected)
+	}
+}
+
+func TestWriteIntent_SMPFormat(t *testing.T) {
+	tmpDir := t.TempDir()
+	
+	intent := testIntent{
+		IntentType: "scaling",
+		Target:     "my-app",
+		Namespace:  "production",
+		Replicas:   5,
+	}
+	
+	err := WriteIntent(intent, tmpDir, "smp")
+	if err != nil {
+		t.Fatalf("WriteIntent failed: %v", err)
+	}
+	
+	// Check JSON file was created
+	jsonPath := filepath.Join(tmpDir, "scaling-patch.json")
+	content, err := os.ReadFile(jsonPath)
+	if err != nil {
+		t.Fatalf("Failed to read output file: %v", err)
+	}
+	
+	// Parse and validate JSON structure
+	var smp map[string]interface{}
+	if err := json.Unmarshal(content, &smp); err != nil {
+		t.Fatalf("Invalid JSON output: %v", err)
+	}
+	
+	// Check structure
+	if smp["apiVersion"] != "apps/v1" {
+		t.Errorf("Wrong apiVersion: %v", smp["apiVersion"])
+	}
+	if smp["kind"] != "Deployment" {
+		t.Errorf("Wrong kind: %v", smp["kind"])
+	}
+	
+	metadata := smp["metadata"].(map[string]interface{})
+	if metadata["name"] != "my-app" {
+		t.Errorf("Wrong name: %v", metadata["name"])
+	}
+	if metadata["namespace"] != "production" {
+		t.Errorf("Wrong namespace: %v", metadata["namespace"])
+	}
+	
+	spec := smp["spec"].(map[string]interface{})
+	if int(spec["replicas"].(float64)) != 5 {
+		t.Errorf("Wrong replicas: %v", spec["replicas"])
+	}
+}
+
+func TestWriteIntent_InvalidIntentType(t *testing.T) {
+	tmpDir := t.TempDir()
+	
+	intent := testIntent{
+		IntentType: "networking", // Not supported
+		Target:     "my-app",
+		Namespace:  "default",
+		Replicas:   3,
+	}
+	
+	err := WriteIntent(intent, tmpDir, "full")
+	if err == nil {
+		t.Fatal("Expected error for unsupported intent type")
+	}
+	
+	expectedErr := "only scaling intent is supported in MVP"
+	if err.Error() != expectedErr {
+		t.Errorf("Unexpected error: got %v, want %v", err.Error(), expectedErr)
+	}
+}
+
+func TestWriteIntent_DefaultFormat(t *testing.T) {
+	tmpDir := t.TempDir()
+	
+	intent := testIntent{
+		IntentType: "scaling",
+		Target:     "test-app",
+		Namespace:  "test-ns",
+		Replicas:   1,
+	}
+	
+	// Test with empty format string (should default to full)
+	err := WriteIntent(intent, tmpDir, "")
+	if err != nil {
+		t.Fatalf("WriteIntent failed: %v", err)
+	}
+	
+	// Check YAML file was created (default behavior)
+	yamlPath := filepath.Join(tmpDir, "scaling-patch.yaml")
+	if _, err := os.Stat(yamlPath); os.IsNotExist(err) {
+		t.Error("Expected YAML file not created with default format")
+	}
+}


### PR DESCRIPTION
This pull request refactors the `porch-publisher` tool to improve maintainability and testability by extracting the intent writing logic into a new internal package, adding flexible output format support, and introducing comprehensive tests. The changes enable output in either YAML or Strategic Merge Patch (SMP) JSON format, improve error handling, and ensure the tool is robustly tested at both the unit and integration levels.

**Refactoring and Core Functionality:**

* Extracted the logic for writing intent manifests into a new `WriteIntent` function in `internal/porch/writer.go`, supporting both "full" (YAML) and "smp" (JSON) formats and improving error handling.
* Updated `cmd/porch-publisher/main.go` to use the new `WriteIntent` function, added a `-format` flag for output format selection, improved usage messages, and enhanced error reporting. [[1]](diffhunk://#diff-14899d8a546c2ae4d5c174776ffe73b6e85aa8c015481f2e5372a9dac5656dcdL8-R12) [[2]](diffhunk://#diff-14899d8a546c2ae4d5c174776ffe73b6e85aa8c015481f2e5372a9dac5656dcdR23-L58)

**Testing Improvements:**

* Added comprehensive unit tests for `WriteIntent` in `internal/porch/writer_test.go`, covering YAML output, SMP JSON output, default format handling, and error cases for unsupported intent types.
* Introduced an integration test for the CLI in `cmd/porch-publisher/main_test.go`, verifying end-to-end behavior for different formats and error scenarios.