### PR TITLE
feat(a1-sim): add A1 policy simulator and planner helper with contrac…

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 **MVP: Demonstrating intent-driven network orchestration with AI-powered translation**
 
-[![Build Status](https://img.shields.io/github/actions/workflow/status/thc1006/nephoran-intent-operator/ci.yaml?branch=main&style=flat-square&logo=github)](https://github.com/thc1006/nephoran-intent-operator/actions/workflows/ci.yaml)
+[![Build Status](https://img.shields.io/github/actions/workflow/status/thc1006/nephoran-intent-operator/ci.yml?branch=main&style=flat-square&logo=github)](https://github.com/thc1006/nephoran-intent-operator/actions/workflows/ci.yml)
 [![Documentation](https://img.shields.io/github/actions/workflow/status/thc1006/nephoran-intent-operator/docs-unified.yml?branch=main&style=flat-square&logo=gitbook&label=docs)](https://thc1006.github.io/nephoran-intent-operator)
 [![Go Version](https://img.shields.io/github/go-mod/go-version/thc1006/nephoran-intent-operator?style=flat-square&logo=go)](https://golang.org/)
 [![License](https://img.shields.io/github/license/thc1006/nephoran-intent-operator?style=flat-square)](LICENSE)
@@ -16,6 +16,7 @@
 [![O-RAN Ready](https://img.shields.io/badge/O--RAN-Ready-blue?style=flat-square&logo=verified)](https://www.o-ran.org/)
 [![Security Scan](https://img.shields.io/github/actions/workflow/status/thc1006/nephoran-intent-operator/security-consolidated.yml?branch=main&style=flat-square&logo=security&label=security)](https://github.com/thc1006/nephoran-intent-operator/actions/workflows/security-consolidated.yml)
 [![Release](https://img.shields.io/github/v/release/thc1006/nephoran-intent-operator?style=flat-square&logo=github)](https://github.com/thc1006/nephoran-intent-operator/releases)
+[![DOI](https://zenodo.org/badge/1026653090.svg)](https://doi.org/10.5281/zenodo.16813086)
 
 </div>
 

--- a/cmd/a1-sim/main.go
+++ b/cmd/a1-sim/main.go
@@ -1,0 +1,17 @@
+package main
+
+import (
+"log"
+"net/http"
+
+"github.com/thc1006/nephoran-intent-operator/internal/a1sim"
+)
+
+func main() {
+mux := http.NewServeMux()
+mux.HandleFunc("/a1/policies", a1sim.SavePolicyHandler("policies"))
+
+addr := ":8081"
+log.Println("A1 policy sim listening on", addr)
+log.Fatal(http.ListenAndServe(addr, mux))
+}

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -4,3 +4,4 @@
 |---|---|---|---|
 | 2025-08-13T11:25:19.8514502+08:00 | feat/a1-policy-sim | a1sim/planner | A1 sim and planner MVP complete |
 | 2025-08-13T11:32:05.4673249+08:00 | feat/a1-policy-sim | a1sim/planner | Aligned with contract schemas |
+| 2025-08-13T12:36:09.6953059+08:00 | feat/a1-policy-sim | a1sim/planner | Fixed critical error handling issues |

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -2,3 +2,5 @@
 
 | timestamp (ISO-8601) | branch | module | summary |
 |---|---|---|---|
+| 2025-08-13T11:25:19.8514502+08:00 | feat/a1-policy-sim | a1sim/planner | A1 sim and planner MVP complete |
+| 2025-08-13T11:32:05.4673249+08:00 | feat/a1-policy-sim | a1sim/planner | Aligned with contract schemas |

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/thc1006/nephoran-intent-operator
 
-go 1.24.1
-
-toolchain go1.24.5
+go 1.23.0
 
 // Go 1.24+ optimization directives for better performance
 //go:build go1.24

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/thc1006/nephoran-intent-operator
 
 go 1.24.1
 
-toolchain go1.24.5
-
 // Go 1.24+ optimization directives for better performance
 //go:build go1.24
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/thc1006/nephoran-intent-operator
 
-go 1.23.0
+go 1.24.1
+
+toolchain go1.24.5
 
 // Go 1.24+ optimization directives for better performance
 //go:build go1.24

--- a/internal/a1sim/handler.go
+++ b/internal/a1sim/handler.go
@@ -1,0 +1,59 @@
+package a1sim
+
+import (
+"encoding/json"
+"net/http"
+"os"
+"path/filepath"
+"time"
+)
+
+// A1Policy matches the a1.policy.schema.json contract
+type A1Policy struct {
+	PolicyTypeID string       `json:"policyTypeId"` // "oran.sim.scaling.v1"
+	Scope        PolicyScope  `json:"scope"`
+	Rules        PolicyRules  `json:"rules"`
+	Notes        string       `json:"notes,omitempty"`
+}
+
+type PolicyScope struct {
+	Namespace string `json:"namespace"`
+	Target    string `json:"target"`
+}
+
+type PolicyRules struct {
+	Metric            string  `json:"metric"` // e.g., "kpm.p95_latency_ms"
+	ScaleOutThreshold float64 `json:"scale_out_threshold"`
+	ScaleInThreshold  float64 `json:"scale_in_threshold"`
+	CooldownSeconds   int     `json:"cooldown_seconds"`
+	MinReplicas       int     `json:"min_replicas"`
+	MaxReplicas       int     `json:"max_replicas"`
+}
+
+func SavePolicyHandler(dir string) http.HandlerFunc {
+return func(w http.ResponseWriter, r *http.Request) {
+if r.Method != http.MethodPost {
+w.WriteHeader(http.StatusMethodNotAllowed)
+return
+}
+if err := os.MkdirAll(dir, 0o755); err != nil {
+http.Error(w, err.Error(), http.StatusInternalServerError)
+return
+}
+var p A1Policy
+if err := json.NewDecoder(r.Body).Decode(&p); err != nil {
+http.Error(w, err.Error(), http.StatusBadRequest)
+return
+}
+name := time.Now().UTC().Format("20060102T150405Z") + ".json"
+path := filepath.Join(dir, name)
+b, _ := json.MarshalIndent(p, "", "  ")
+if err := os.WriteFile(path, b, 0o644); err != nil {
+http.Error(w, err.Error(), http.StatusInternalServerError)
+return
+}
+w.Header().Set("Content-Type", "application/json")
+w.WriteHeader(http.StatusAccepted)
+w.Write([]byte(`{"status":"accepted","saved":"` + path + `"}`))
+}
+}

--- a/internal/a1sim/handler.go
+++ b/internal/a1sim/handler.go
@@ -47,7 +47,11 @@ return
 }
 name := time.Now().UTC().Format("20060102T150405Z") + ".json"
 path := filepath.Join(dir, name)
-b, _ := json.MarshalIndent(p, "", "  ")
+b, err := json.MarshalIndent(p, "", "  ")
+if err != nil {
+http.Error(w, "failed to marshal policy: "+err.Error(), http.StatusInternalServerError)
+return
+}
 if err := os.WriteFile(path, b, 0o644); err != nil {
 http.Error(w, err.Error(), http.StatusInternalServerError)
 return

--- a/internal/a1sim/handler_test.go
+++ b/internal/a1sim/handler_test.go
@@ -1,0 +1,49 @@
+package a1sim
+
+import (
+"bytes"
+"encoding/json"
+"net/http"
+"net/http/httptest"
+"os"
+"path/filepath"
+"testing"
+)
+
+func TestSavePolicyHandler_OK(t *testing.T) {
+tmp := t.TempDir()
+h := SavePolicyHandler(tmp)
+
+p := A1Policy{
+		PolicyTypeID: "oran.sim.scaling.v1",
+		Scope: PolicyScope{
+			Namespace: "ran-a",
+			Target:    "nf-sim",
+		},
+		Rules: PolicyRules{
+			Metric:            "kpm.p95_latency_ms",
+			ScaleOutThreshold: 100.0,
+			ScaleInThreshold:  50.0,
+			CooldownSeconds:   60,
+			MinReplicas:       1,
+			MaxReplicas:       10,
+		},
+	}
+b, _ := json.Marshal(p)
+
+req := httptest.NewRequest(http.MethodPost, "/a1/policies", bytes.NewReader(b))
+req.Header.Set("Content-Type", "application/json")
+rr := httptest.NewRecorder()
+h.ServeHTTP(rr, req)
+
+if rr.Code != http.StatusAccepted {
+t.Fatalf("want 202, got %d, body=%s", rr.Code, rr.Body.String())
+}
+files, _ := os.ReadDir(tmp)
+if len(files) == 0 {
+t.Fatalf("expected a saved policy in %s", tmp)
+}
+if filepath.Ext(files[0].Name()) != ".json" {
+t.Fatalf("expected .json file, got %s", files[0].Name())
+}
+}

--- a/internal/planner/planner.go
+++ b/internal/planner/planner.go
@@ -5,6 +5,7 @@ import (
 "encoding/json"
 "fmt"
 "net/http"
+"time"
 )
 
 // Intent matches the intent.schema.json contract
@@ -18,11 +19,22 @@ type Intent struct {
 	CorrelationID string `json:"correlation_id,omitempty"` // optional trace id
 }
 
+// httpClient is a reusable HTTP client with timeout
+var httpClient = &http.Client{
+	Timeout: 30 * time.Second,
+}
+
 func PostIntent(url string, in Intent) error {
-b, _ := json.Marshal(in)
-req, _ := http.NewRequest(http.MethodPost, url, bytes.NewReader(b))
+b, err := json.Marshal(in)
+if err != nil {
+return fmt.Errorf("failed to marshal intent: %w", err)
+}
+req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(b))
+if err != nil {
+return fmt.Errorf("failed to create request: %w", err)
+}
 req.Header.Set("Content-Type", "application/json")
-resp, err := http.DefaultClient.Do(req)
+resp, err := httpClient.Do(req)
 if err != nil {
 return err
 }

--- a/internal/planner/planner.go
+++ b/internal/planner/planner.go
@@ -1,0 +1,34 @@
+package planner
+
+import (
+"bytes"
+"encoding/json"
+"fmt"
+"net/http"
+)
+
+// Intent matches the intent.schema.json contract
+type Intent struct {
+	IntentType    string `json:"intent_type"`              // "scaling"
+	Target        string `json:"target"`                   // deployment name
+	Namespace     string `json:"namespace"`                // k8s namespace
+	Replicas      int    `json:"replicas"`                 // desired replicas (1-100)
+	Reason        string `json:"reason,omitempty"`         // optional reason
+	Source        string `json:"source,omitempty"`         // "user", "planner", or "test"
+	CorrelationID string `json:"correlation_id,omitempty"` // optional trace id
+}
+
+func PostIntent(url string, in Intent) error {
+b, _ := json.Marshal(in)
+req, _ := http.NewRequest(http.MethodPost, url, bytes.NewReader(b))
+req.Header.Set("Content-Type", "application/json")
+resp, err := http.DefaultClient.Do(req)
+if err != nil {
+return err
+}
+defer resp.Body.Close()
+if resp.StatusCode >= 300 {
+return fmt.Errorf("post intent status=%d", resp.StatusCode)
+}
+return nil
+}

--- a/internal/planner/planner_test.go
+++ b/internal/planner/planner_test.go
@@ -1,0 +1,31 @@
+package planner
+
+import (
+"encoding/json"
+"net/http"
+"net/http/httptest"
+"testing"
+)
+
+func TestPostIntent_OK(t *testing.T) {
+s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+var in Intent
+if err := json.NewDecoder(r.Body).Decode(&in); err != nil {
+t.Fatalf("bad json: %v", err)
+}
+w.WriteHeader(http.StatusAccepted)
+}))
+defer s.Close()
+
+err := PostIntent(s.URL, Intent{
+IntentType: "scaling",
+ Target:     "nf-sim",
+		Namespace:  "ran-a",
+		Replicas:   3,
+		Source:     "planner",
+		Reason:     "test scaling intent",
+	})
+if err != nil {
+t.Fatalf("PostIntent: %v", err)
+}
+}

--- a/policies/20250812T141851Z.json
+++ b/policies/20250812T141851Z.json
@@ -1,9 +1,0 @@
-{
-  "policy_type": "scaling_policy",
-  "target": "nf-sim",
-  "namespace": "ran-a",
-  "min_replicas": 1,
-  "max_replicas": 8,
-  "high_threshold": 0.8,
-  "low_threshold": 0.3
-}

--- a/policies/20250812T141851Z.json
+++ b/policies/20250812T141851Z.json
@@ -1,0 +1,9 @@
+{
+  "policy_type": "scaling_policy",
+  "target": "nf-sim",
+  "namespace": "ran-a",
+  "min_replicas": 1,
+  "max_replicas": 8,
+  "high_threshold": 0.8,
+  "low_threshold": 0.3
+}


### PR DESCRIPTION
This pull request introduces an MVP implementation for an A1 policy simulator and a planner module, aligning with contract schemas and providing basic HTTP interfaces and tests. The main changes include new modules for handling A1 policy storage and intent posting, along with updates to documentation and metadata.

**A1 Policy Simulator and Planner MVP:**

* Added a new `a1sim` module with an HTTP handler (`SavePolicyHandler`) that accepts A1 policy POST requests, validates and saves them as JSON files, matching the `a1.policy.schema.json` contract. Includes a main entrypoint in `cmd/a1-sim/main.go` to run the simulator server. [[1]](diffhunk://#diff-1238121d15f0231cf9dbfaa94661509c6e84b475e68d2b8e3228c988c65d1e2aR1-R17) [[2]](diffhunk://#diff-843dc5affd4d8999b628919d21bef41476d04f7ac153171f55957b1faedda7e7R1-R59)
* Added corresponding tests for the A1 policy handler to ensure policies are correctly saved and validated.

**Planner Module:**

* Introduced a `planner` module with an `Intent` struct matching the `intent.schema.json` contract and a `PostIntent` function to send intent POST requests. Includes tests for the intent posting logic. [[1]](diffhunk://#diff-c5881c0019f7676e641022d5aaf14139aacffe478377d1a1b8c35d1ef79095a2R1-R34) [[2]](diffhunk://#diff-16afdb9d44654b52029b3a5517863e9431d6ccae47800ddf42882447a06e8409R1-R31)

**Documentation and Metadata Updates:**

* Updated `README.md` badges for correct CI workflow file extension and added a DOI badge for Zenodo. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L9-R9) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R19)
* Updated `docs/PROGRESS.md` to reflect completion and schema alignment of the A1 sim and planner MVP.
* Added an example policy file in `policies/20250812T141851Z.json`.