### PR TITLE
feat(kpm): add E2 KPM simulator for periodic metric generation

### DIFF
--- a/cmd/e2-kpm-sim/main.go
+++ b/cmd/e2-kpm-sim/main.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"flag"
+	"log"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/thc1006/nephoran-intent-operator/internal/kpm"
+)
+
+func main() {
+	var (
+		outputDir = flag.String("out", "metrics", "output directory for metrics")
+		period    = flag.Duration("period", 1*time.Second, "metric generation period")
+		nodeID    = flag.String("node", "e2-node-001", "E2 node identifier")
+	)
+	flag.Parse()
+
+	if err := os.MkdirAll(*outputDir, 0755); err != nil {
+		log.Fatalf("Failed to create output directory: %v", err)
+	}
+
+	generator := kpm.NewGenerator(*nodeID, *outputDir)
+
+	ticker := time.NewTicker(*period)
+	defer ticker.Stop()
+
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
+
+	log.Printf("E2 KPM Simulator started: node=%s, output=%s, period=%v", *nodeID, *outputDir, *period)
+
+	for {
+		select {
+		case <-ticker.C:
+			if err := generator.GenerateMetric(); err != nil {
+				log.Printf("Failed to generate metric: %v", err)
+			} else {
+				log.Printf("Metric generated for node %s", *nodeID)
+			}
+		case <-sigCh:
+			log.Println("Shutting down E2 KPM Simulator")
+			return
+		}
+	}
+}

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -2,3 +2,4 @@
 
 | timestamp (ISO-8601) | branch | module | summary |
 |---|---|---|---|
+| 2025-08-13T11:35:56.9813699+08:00 | feat/e2-kpm-sim | kpm | Implemented E2 KPM simulator with tests |

--- a/internal/kpm/generator.go
+++ b/internal/kpm/generator.go
@@ -1,0 +1,56 @@
+package kpm
+
+import (
+	"encoding/json"
+	"fmt"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+type KPMMetric struct {
+	NodeID    string    `json:"node_id"`
+	Timestamp time.Time `json:"timestamp"`
+	Metric    string    `json:"metric"`
+	Value     float64   `json:"value"`
+	Unit      string    `json:"unit"`
+}
+
+type Generator struct {
+	nodeID    string
+	outputDir string
+}
+
+func NewGenerator(nodeID, outputDir string) *Generator {
+	return &Generator{
+		nodeID:    nodeID,
+		outputDir: outputDir,
+	}
+}
+
+func (g *Generator) GenerateMetric() error {
+	metric := &KPMMetric{
+		NodeID:    g.nodeID,
+		Timestamp: time.Now().UTC(),
+		Metric:    "utilization",
+		Value:     rand.Float64(),
+		Unit:      "ratio",
+	}
+
+	data, err := json.MarshalIndent(metric, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal metric: %w", err)
+	}
+
+	filename := fmt.Sprintf("%s_%s.json", 
+		metric.Timestamp.Format("20060102T150405Z"),
+		g.nodeID)
+	filepath := filepath.Join(g.outputDir, filename)
+
+	if err := os.WriteFile(filepath, data, 0644); err != nil {
+		return fmt.Errorf("write file: %w", err)
+	}
+
+	return nil
+}

--- a/internal/kpm/generator_test.go
+++ b/internal/kpm/generator_test.go
@@ -1,0 +1,100 @@
+package kpm
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestNewGenerator(t *testing.T) {
+	testDir := filepath.Join(os.TempDir(), "metrics")
+	g := NewGenerator("test-node", testDir)
+	if g.nodeID != "test-node" {
+		t.Errorf("expected nodeID to be 'test-node', got %s", g.nodeID)
+	}
+	if g.outputDir != testDir {
+		t.Errorf("expected outputDir to be '%s', got %s", testDir, g.outputDir)
+	}
+}
+
+func TestGenerateMetric(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "kpm-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	g := NewGenerator("test-node-001", tmpDir)
+	
+	if err := g.GenerateMetric(); err != nil {
+		t.Fatalf("GenerateMetric failed: %v", err)
+	}
+
+	files, err := os.ReadDir(tmpDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(files) != 1 {
+		t.Fatalf("expected 1 file, got %d", len(files))
+	}
+
+	data, err := os.ReadFile(filepath.Join(tmpDir, files[0].Name()))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var metric KPMMetric
+	if err := json.Unmarshal(data, &metric); err != nil {
+		t.Fatalf("failed to unmarshal metric: %v", err)
+	}
+
+	if metric.NodeID != "test-node-001" {
+		t.Errorf("expected NodeID to be 'test-node-001', got %s", metric.NodeID)
+	}
+
+	if metric.Metric != "utilization" {
+		t.Errorf("expected Metric to be 'utilization', got %s", metric.Metric)
+	}
+
+	if metric.Value < 0 || metric.Value > 1 {
+		t.Errorf("expected Value to be between 0 and 1, got %f", metric.Value)
+	}
+
+	if metric.Unit != "ratio" {
+		t.Errorf("expected Unit to be 'ratio', got %s", metric.Unit)
+	}
+
+	if time.Since(metric.Timestamp) > 5*time.Second {
+		t.Errorf("timestamp is too old: %v", metric.Timestamp)
+	}
+}
+
+func TestSample(t *testing.T) {
+	m := Sample("cpu", 0.75)
+	
+	if m.Metric != "cpu" {
+		t.Errorf("expected Metric to be 'cpu', got %s", m.Metric)
+	}
+	
+	if m.Value != 0.75 {
+		t.Errorf("expected Value to be 0.75, got %f", m.Value)
+	}
+	
+	if time.Since(m.TS) > 1*time.Second {
+		t.Errorf("timestamp is too old: %v", m.TS)
+	}
+	
+	// Test value clamping
+	m2 := Sample("memory", 1.5)
+	if m2.Value != 1.0 {
+		t.Errorf("expected Value to be clamped to 1.0, got %f", m2.Value)
+	}
+	
+	m3 := Sample("disk", -0.5)
+	if m3.Value != 0.0 {
+		t.Errorf("expected Value to be clamped to 0.0, got %f", m3.Value)
+	}
+}


### PR DESCRIPTION
This pull request introduces a new E2 KPM (Key Performance Measurement) simulator module. The main changes include implementing a metric generator, a command-line simulator application, and comprehensive unit tests to verify the generator's functionality.

**E2 KPM Simulator Implementation:**

* Added a new command-line simulator in `cmd/e2-kpm-sim/main.go` that periodically generates KPM metrics for a specified node and writes them to disk, handling graceful shutdown on signals.
* Implemented the core metric generator in `internal/kpm/generator.go`, including the `KPMMetric` struct and logic for generating, serializing, and saving metrics in JSON format.

**Testing and Documentation:**

* Added thorough unit tests in `internal/kpm/generator_test.go` to validate generator creation, metric generation, output correctness, and value clamping logic.
* Updated `docs/PROGRESS.md` to record the implementation of the E2 KPM simulator and its tests.