### PR TITLE
test(config): stabilize llm validation test expectations

### DIFF
--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -97,3 +97,4 @@ Updates are tracked here in append-only format.
 | 2026-02-13T09:50:04+00:00 | chore/ci-workflow-prune-20260213 | .github/workflows | Pruned deprecated workflows; added pr-validation and CI Status-aligned policies |
 | 2026-02-13T10:01:57+00:00 | chore/ci-workflow-prune-20260213 | .github/workflows | Relaxed PR validation test step to non-blocking warnings for baseline stability |
 | 2026-02-13T10:42:16+00:00 | chore/check-policy-normalization-20260213 | workflows | required checks normalized to real contexts |
+| 2026-02-13T11:00:25+00:00 | chore/pkg-config-test-stabilization-20260213 | pkg/config | decoupled config tests from CORS validation constraints |

--- a/pkg/config/llm_processor_test.go
+++ b/pkg/config/llm_processor_test.go
@@ -195,6 +195,7 @@ func TestLLMProcessorConfig_Validate_RequiredFields(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := tt.setupConfig()
+			cfg.CORSEnabled = false // CORS behavior is covered in dedicated CORS tests.
 			err := cfg.Validate()
 
 			if tt.wantErr {
@@ -286,6 +287,7 @@ func TestLLMProcessorConfig_Validate_RAGFeatureFlags(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := tt.setupConfig()
+			cfg.CORSEnabled = false // CORS behavior is covered in dedicated CORS tests.
 			err := cfg.Validate()
 
 			if tt.wantErr {
@@ -375,13 +377,14 @@ func TestLLMProcessorConfig_Validate_LogicalConstraints(t *testing.T) {
 			},
 			description: "Excessive circuit breaker threshold should be invalid",
 			wantErr:     true,
-			errMsg:      "CIRCUIT_BREAKER_THRESHOLD should be reasonable (??0)",
+			errMsg:      "CIRCUIT_BREAKER_THRESHOLD should be reasonable (≤50)",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := tt.setupConfig()
+			cfg.CORSEnabled = false // CORS behavior is covered in dedicated CORS tests.
 			err := cfg.Validate()
 
 			if tt.wantErr {
@@ -405,6 +408,7 @@ func TestLLMProcessorConfig_Validate_MultipleErrors(t *testing.T) {
 	cfg.MaxConcurrentStreams = 1500  // Too high
 	cfg.MaxContextTokens = 50000     // Too high
 	cfg.CircuitBreakerThreshold = 75 // Too high
+	cfg.CORSEnabled = false          // CORS behavior is covered in dedicated CORS tests.
 
 	err := cfg.Validate()
 	assert.Error(t, err)
@@ -415,7 +419,7 @@ func TestLLMProcessorConfig_Validate_MultipleErrors(t *testing.T) {
 	assert.Contains(t, errMsg, "API_KEY is required when API key authentication is enabled")
 	assert.Contains(t, errMsg, "MAX_CONCURRENT_STREAMS should not exceed 1000 for performance reasons")
 	assert.Contains(t, errMsg, "MAX_CONTEXT_TOKENS should not exceed 32000 for most models")
-	assert.Contains(t, errMsg, "CIRCUIT_BREAKER_THRESHOLD should be reasonable (??0)")
+	assert.Contains(t, errMsg, "CIRCUIT_BREAKER_THRESHOLD should be reasonable (≤50)")
 }
 
 func TestLLMProcessorConfig_Validate_CORS(t *testing.T) {


### PR DESCRIPTION
## Summary
- decouple non-CORS validation test groups from CORS-required-origin checks
- fix circuit breaker threshold expectation string to match validator output
- keep CORS-specific assertions in dedicated CORS test suite

## Validation
- GOMAXPROCS=$(nproc) go test -count=1 -p $(nproc) ./pkg/config/...
- GOMAXPROCS=$(nproc) make -f Makefile.ci ci-ultra-fast
