### PR TITLE
chore(ci): make config scoped tests blocking

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -16,3 +16,4 @@
 - Ubuntu-only runners.
 - Per-branch concurrency group: `${{ github.ref }}`.
 - Required gate contexts for protected branches: `Basic Validation`, `CI Status`.
+- `Basic Validation` currently blocks on build + `pkg/config` tests; `pkg/auth` and `internal/security` remain advisory.

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -38,9 +38,10 @@ jobs:
 
       - name: Run scoped tests
         run: |
-          go test -short -timeout=2m ./pkg/config/... || echo "⚠️ Config tests failed (non-blocking)"
-          go test -short -timeout=2m ./pkg/auth/... || echo "⚠️ Auth tests failed (non-blocking)"
-          go test -short -timeout=2m ./internal/security/... || echo "⚠️ Security tests failed (non-blocking)"
+          NPROC="$(nproc)"
+          go test -short -timeout=2m -p "$NPROC" ./pkg/config/...
+          go test -short -timeout=2m -p "$NPROC" ./pkg/auth/... || echo "⚠️ Auth tests failed (non-blocking)"
+          go test -short -timeout=2m -p "$NPROC" ./internal/security/... || echo "⚠️ Security tests failed (non-blocking)"
 
   ci-status:
     name: CI Status

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -98,3 +98,4 @@ Updates are tracked here in append-only format.
 | 2026-02-13T10:01:57+00:00 | chore/ci-workflow-prune-20260213 | .github/workflows | Relaxed PR validation test step to non-blocking warnings for baseline stability |
 | 2026-02-13T10:42:16+00:00 | chore/check-policy-normalization-20260213 | workflows | required checks normalized to real contexts |
 | 2026-02-13T11:00:25+00:00 | chore/pkg-config-test-stabilization-20260213 | pkg/config | decoupled config tests from CORS validation constraints |
+| 2026-02-13T11:08:10+00:00 | chore/pr-validation-tighten-config-20260213 | workflows | made pkg/config scoped tests blocking in PR gate |


### PR DESCRIPTION
## Summary
- make `pkg/config` scoped tests blocking in `pr-validation.yml`
- keep `pkg/auth` and `internal/security` scoped tests advisory while they remain unstable
- run scoped tests with `-p $(nproc)` to better use runner hardware
- document current gating behavior in workflow README

## Validation
- .github/workflows/verify-consolidation.sh
- GOMAXPROCS=$(nproc) make -f Makefile.ci ci-ultra-fast
- go test -short -timeout=2m -p $(nproc) ./pkg/config/...
