### PR TITLE
chore(ci): add blocking auth smoke gate

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -16,4 +16,4 @@
 - Ubuntu-only runners.
 - Per-branch concurrency group: `${{ github.ref }}`.
 - Required gate contexts for protected branches: `Basic Validation`, `CI Status`.
-- `Basic Validation` currently blocks on build + `pkg/config` tests; `pkg/auth` and `internal/security` remain advisory.
+- `Basic Validation` currently blocks on build + `pkg/config` + auth provider smoke tests; full `pkg/auth` and `internal/security` remain advisory.

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -40,6 +40,7 @@ jobs:
         run: |
           NPROC="$(nproc)"
           go test -short -timeout=2m -p "$NPROC" ./pkg/config/...
+          go test -short -timeout=2m -p "$NPROC" ./pkg/auth/providers -run 'TestGitHubProvider_ExchangeCodeForToken|TestGoogleProvider_ExchangeCodeForToken'
           go test -short -timeout=2m -p "$NPROC" ./pkg/auth/... || echo "⚠️ Auth tests failed (non-blocking)"
           go test -short -timeout=2m -p "$NPROC" ./internal/security/... || echo "⚠️ Security tests failed (non-blocking)"
 

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -99,3 +99,4 @@ Updates are tracked here in append-only format.
 | 2026-02-13T10:42:16+00:00 | chore/check-policy-normalization-20260213 | workflows | required checks normalized to real contexts |
 | 2026-02-13T11:00:25+00:00 | chore/pkg-config-test-stabilization-20260213 | pkg/config | decoupled config tests from CORS validation constraints |
 | 2026-02-13T11:08:10+00:00 | chore/pr-validation-tighten-config-20260213 | workflows | made pkg/config scoped tests blocking in PR gate |
+| 2026-02-13T11:19:07+00:00 | chore/pr-validation-auth-smoke-gate-20260213 | workflows | added blocking auth provider smoke tests to PR gate |


### PR DESCRIPTION
## Summary
- add a blocking auth provider smoke-test gate to `pr-validation.yml`
- keep full `pkg/auth` and `internal/security` suites advisory until stabilized
- preserve high-parallel execution (`-p $(nproc)`) for scoped checks

## Validation
- .github/workflows/verify-consolidation.sh
- GOMAXPROCS=$(nproc) make -f Makefile.ci ci-ultra-fast
- go test -short -timeout=2m -p $(nproc) ./pkg/config/...
- go test -short -timeout=2m -p $(nproc) ./pkg/auth/providers -run 'TestGitHubProvider_ExchangeCodeForToken|TestGoogleProvider_ExchangeCodeForToken'
