### PR TITLE
test(security): stabilize json limit checks and gate

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -16,4 +16,4 @@
 - Ubuntu-only runners.
 - Per-branch concurrency group: `${{ github.ref }}`.
 - Required gate contexts for protected branches: `Basic Validation`, `CI Status`.
-- `Basic Validation` currently blocks on build + `pkg/config` + auth provider smoke tests; full `pkg/auth` and `internal/security` remain advisory.
+- `Basic Validation` currently blocks on build + `pkg/config` + auth provider smoke tests + `internal/security`; full `pkg/auth` remains advisory.

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -42,7 +42,7 @@ jobs:
           go test -short -timeout=2m -p "$NPROC" ./pkg/config/...
           go test -short -timeout=2m -p "$NPROC" ./pkg/auth/providers -run 'TestGitHubProvider_ExchangeCodeForToken|TestGoogleProvider_ExchangeCodeForToken'
           go test -short -timeout=2m -p "$NPROC" ./pkg/auth/... || echo "⚠️ Auth tests failed (non-blocking)"
-          go test -short -timeout=2m -p "$NPROC" ./internal/security/... || echo "⚠️ Security tests failed (non-blocking)"
+          go test -short -timeout=2m -p "$NPROC" ./internal/security/...
 
   ci-status:
     name: CI Status

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -101,3 +101,4 @@ Updates are tracked here in append-only format.
 | 2026-02-13T11:08:10+00:00 | chore/pr-validation-tighten-config-20260213 | workflows | made pkg/config scoped tests blocking in PR gate |
 | 2026-02-13T11:19:07+00:00 | chore/pr-validation-auth-smoke-gate-20260213 | workflows | added blocking auth provider smoke tests to PR gate |
 | 2026-02-13T11:47:41+00:00 | chore/auth-fullsuite-stabilization-p1-20260213 | pkg/auth | phase1 stabilized auth suite, providers, and logger nil-safety |
+| 2026-02-13T12:16:38+00:00 | chore/security-suite-stabilization-p1-20260213 | internal/security | fixed JSON limit test and made security scoped tests blocking |

--- a/internal/security/jsonlimit_test.go
+++ b/internal/security/jsonlimit_test.go
@@ -200,9 +200,9 @@ func TestCountingReader(t *testing.T) {
 }
 
 func TestMaxJSONBytesConstant(t *testing.T) {
-	// Verify the constant is set to 5MB as defined
-	assert.Equal(t, int64(MaxJSONBytes), int64(5*1024*1024))
-	assert.Equal(t, int64(MaxJSONBytes), int64(5<<20))
+	// Verify the constant is set to 1MB as defined
+	assert.Equal(t, int64(1*1024*1024), int64(MaxJSONBytes))
+	assert.Equal(t, int64(1<<20), int64(MaxJSONBytes))
 }
 
 func BenchmarkValidateAndLimitJSON(b *testing.B) {


### PR DESCRIPTION
## Summary
- fix `TestMaxJSONBytesConstant` expectation to match the defined 1MB security limit
- make `internal/security` scoped tests blocking in `pr-validation.yml`
- update workflows README to reflect current gate policy

## Validation
- GOMAXPROCS=$(nproc) go test -count=1 -p $(nproc) ./internal/security/...
- .github/workflows/verify-consolidation.sh
- GOMAXPROCS=$(nproc) make -f Makefile.ci ci-ultra-fast
- go test -short -timeout=2m -p $(nproc) ./pkg/config/...
- go test -short -timeout=2m -p $(nproc) ./pkg/auth/providers -run 'TestGitHubProvider_ExchangeCodeForToken|TestGoogleProvider_ExchangeCodeForToken'
- go test -short -timeout=2m -p $(nproc) ./pkg/auth/...
- go test -short -timeout=2m -p $(nproc) ./internal/security/...
