### PR TITLE
chore(ci): normalize to single required check context

### DIFF
--- a/.github/workflows/DEPRECATED-WORKFLOWS.md
+++ b/.github/workflows/DEPRECATED-WORKFLOWS.md
@@ -2,7 +2,7 @@
 
 These workflows were removed during CI consolidation in favor of:
 - `ci-2025.yml` (primary CI)
-- `pr-validation.yml` (required PR gate producing `Basic Validation` + `CI Status`)
+- `pr-validation.yml` (required PR gate producing `Basic Validation`)
 - `ubuntu-ci.yml` (manual full suite)
 - `emergency-merge.yml` (manual emergency)
 - `go-module-cache.yml` (reusable cache helper)

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -2,7 +2,7 @@
 
 ## Active workflows
 - `ci-2025.yml`: primary CI workflow
-- `pr-validation.yml`: PR gate checks (`Basic Validation`, `CI Status`)
+- `pr-validation.yml`: PR gate checks (`Basic Validation`)
 - `ubuntu-ci.yml`: manual full validation suite
 - `emergency-merge.yml`: manual emergency pipeline
 - `go-module-cache.yml`: reusable cache workflow
@@ -15,5 +15,5 @@
 ## Policy
 - Ubuntu-only runners.
 - Per-branch concurrency group: `${{ github.ref }}`.
-- Required gate contexts for protected branches: `Basic Validation`, `CI Status`.
+- Required gate context for protected branches: `Basic Validation`.
 - `Basic Validation` currently blocks on build + `pkg/config` + full `pkg/auth` + `internal/security`.

--- a/.github/workflows/WORKFLOWS-ALLOWLIST.md
+++ b/.github/workflows/WORKFLOWS-ALLOWLIST.md
@@ -15,4 +15,3 @@ Allowed active workflows:
 
 Required protected-branch check contexts:
 - Basic Validation
-- CI Status

--- a/.github/workflows/branch-protection-setup.yml
+++ b/.github/workflows/branch-protection-setup.yml
@@ -83,7 +83,7 @@ jobs:
               policies='{
                 "required_status_checks": {
                   "strict": true,
-                  "contexts": ["Basic Validation", "CI Status"]
+                  "contexts": ["Basic Validation"]
                 },
                 "enforce_admins": false,
                 "required_pull_request_reviews": {
@@ -103,7 +103,7 @@ jobs:
               policies='{
                 "required_status_checks": {
                   "strict": true,
-                  "contexts": ["Basic Validation", "CI Status"]
+                  "contexts": ["Basic Validation"]
                 },
                 "enforce_admins": false,
                 "required_pull_request_reviews": {
@@ -126,7 +126,7 @@ jobs:
               policies='{
                 "required_status_checks": {
                   "strict": true,
-                  "contexts": ["Basic Validation", "CI Status"]
+                  "contexts": ["Basic Validation"]
                 },
                 "enforce_admins": true,
                 "required_pull_request_reviews": {
@@ -153,7 +153,7 @@ jobs:
               policies='{
                 "required_status_checks": {
                   "strict": true,
-                  "contexts": ["Basic Validation", "CI Status"]
+                  "contexts": ["Basic Validation"]
                 },
                 "enforce_admins": true,
                 "required_pull_request_reviews": {
@@ -180,7 +180,7 @@ jobs:
               policies='{
                 "required_status_checks": {
                   "strict": true,
-                  "contexts": ["Basic Validation", "CI Status"]
+                  "contexts": ["Basic Validation"]
                 },
                 "enforce_admins": true,
                 "required_pull_request_reviews": {

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -42,18 +42,3 @@ jobs:
           go test -short -timeout=2m -p "$NPROC" ./pkg/config/...
           go test -short -timeout=2m -p "$NPROC" ./pkg/auth/...
           go test -short -timeout=2m -p "$NPROC" ./internal/security/...
-
-  ci-status:
-    name: CI Status
-    runs-on: ubuntu-latest
-    needs: basic-validation
-    if: always()
-    steps:
-      - name: Enforce required status outcome
-        run: |
-          if [ "${{ needs.basic-validation.result }}" = "success" ]; then
-            echo "CI Status: PASS"
-            exit 0
-          fi
-          echo "CI Status: FAIL"
-          exit 1

--- a/.github/workflows/verify-consolidation.sh
+++ b/.github/workflows/verify-consolidation.sh
@@ -34,11 +34,6 @@ if ! rg -n "name:\s*Basic Validation" .github/workflows/pr-validation.yml >/dev/
   exit 1
 fi
 
-if ! rg -n "name:\s*CI Status" .github/workflows/pr-validation.yml >/dev/null 2>&1; then
-  echo "FAIL: CI Status check missing in pr-validation.yml"
-  exit 1
-fi
-
 if [[ $missing -ne 0 ]]; then
   exit 1
 fi

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -104,3 +104,4 @@ Updates are tracked here in append-only format.
 | 2026-02-13T12:16:38+00:00 | chore/security-suite-stabilization-p1-20260213 | internal/security | fixed JSON limit test and made security scoped tests blocking |
 | 2026-02-13T12:22:50+00:00 | chore/pr-validation-full-auth-blocking-20260213 | workflows | made full pkg/auth scoped tests blocking in PR gate |
 | 2026-02-13T12:31:32+00:00 | chore/pr-validation-remove-redundant-auth-smoke-20260213 | workflows | removed redundant auth provider smoke step from PR gate |
+| 2026-02-13T13:07:40+00:00 | chore/gate-single-context-normalization-20260213 | workflows | normalized required checks to single Basic Validation context |


### PR DESCRIPTION
## Summary
- remove `CI Status` job from `pr-validation.yml`
- align policy-as-code and workflow docs to single required context: `Basic Validation`
- update consolidation verifier to require only `Basic Validation`
- update live ruleset `7316099` required status checks to Basic Validation only

## Validation
- .github/workflows/verify-consolidation.sh
- GOMAXPROCS=$(nproc) make -f Makefile.ci ci-ultra-fast
- go test -short -timeout=2m -p $(nproc) ./pkg/config/...
- go test -short -timeout=2m -p $(nproc) ./pkg/auth/...
- go test -short -timeout=2m -p $(nproc) ./internal/security/...
