### PR TITLE
chore(ci): parallelize PR validation under single gate

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -16,4 +16,4 @@
 - Ubuntu-only runners.
 - Per-branch concurrency group: `${{ github.ref }}`.
 - Required gate context for protected branches: `Basic Validation`.
-- `Basic Validation` currently blocks on build + `pkg/config` + full `pkg/auth` + `internal/security`.
+- `Basic Validation` aggregates parallel blocking jobs for build + `pkg/config` + full `pkg/auth` + `internal/security`.

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -14,8 +14,8 @@ permissions:
   contents: read
 
 jobs:
-  basic-validation:
-    name: Basic Validation
+  build-validation:
+    name: Build Validation
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -36,9 +36,76 @@ jobs:
       - name: Build critical components
         run: make -f Makefile.ci ci-ultra-fast
 
-      - name: Run scoped tests
+  config-tests:
+    name: Config Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.24.0'
+          cache: true
+
+      - name: Run config scoped tests
         run: |
           NPROC="$(nproc)"
           go test -short -timeout=2m -p "$NPROC" ./pkg/config/...
+
+  auth-tests:
+    name: Auth Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 12
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.24.0'
+          cache: true
+
+      - name: Run auth scoped tests
+        run: |
+          NPROC="$(nproc)"
           go test -short -timeout=2m -p "$NPROC" ./pkg/auth/...
+
+  security-tests:
+    name: Security Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.24.0'
+          cache: true
+
+      - name: Run internal security scoped tests
+        run: |
+          NPROC="$(nproc)"
           go test -short -timeout=2m -p "$NPROC" ./internal/security/...
+
+  basic-validation:
+    name: Basic Validation
+    runs-on: ubuntu-latest
+    needs: [build-validation, config-tests, auth-tests, security-tests]
+    if: always()
+    steps:
+      - name: Enforce required status outcome
+        run: |
+          if [ "${{ needs.build-validation.result }}" != "success" ] || \
+             [ "${{ needs.config-tests.result }}" != "success" ] || \
+             [ "${{ needs.auth-tests.result }}" != "success" ] || \
+             [ "${{ needs.security-tests.result }}" != "success" ]; then
+            echo "Basic Validation: FAIL"
+            exit 1
+          fi
+          echo "Basic Validation: PASS"

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -105,3 +105,4 @@ Updates are tracked here in append-only format.
 | 2026-02-13T12:22:50+00:00 | chore/pr-validation-full-auth-blocking-20260213 | workflows | made full pkg/auth scoped tests blocking in PR gate |
 | 2026-02-13T12:31:32+00:00 | chore/pr-validation-remove-redundant-auth-smoke-20260213 | workflows | removed redundant auth provider smoke step from PR gate |
 | 2026-02-13T13:07:40+00:00 | chore/gate-single-context-normalization-20260213 | workflows | normalized required checks to single Basic Validation context |
+| 2026-02-13T13:19:19+00:00 | chore/pr-validation-parallel-blocking-20260213 | workflows | parallelized PR validation jobs under Basic Validation gate |


### PR DESCRIPTION
## Summary
- split PR validation into parallel blocking jobs: build, config, auth, and security
- keep a single required context by aggregating results into the `Basic Validation` job
- update workflow README to describe the parallel aggregated gate

## Validation
- .github/workflows/verify-consolidation.sh
- GOMAXPROCS=$(nproc) make -f Makefile.ci ci-ultra-fast
- go test -short -timeout=2m -p $(nproc) ./pkg/config/...
- go test -short -timeout=2m -p $(nproc) ./pkg/auth/...
- go test -short -timeout=2m -p $(nproc) ./internal/security/...
