### PR TITLE
chore(ci): shard auth PR validation tests

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -55,8 +55,8 @@ jobs:
           NPROC="$(nproc)"
           go test -short -timeout=2m -p "$NPROC" ./pkg/config/...
 
-  auth-tests:
-    name: Auth Tests
+  auth-core-tests:
+    name: Auth Core Tests
     runs-on: ubuntu-latest
     timeout-minutes: 12
     steps:
@@ -69,10 +69,29 @@ jobs:
           go-version: '1.24.0'
           cache: true
 
-      - name: Run auth scoped tests
+      - name: Run auth core scoped tests
         run: |
           NPROC="$(nproc)"
-          go test -short -timeout=2m -p "$NPROC" ./pkg/auth/...
+          go test -short -timeout=2m -p "$NPROC" ./pkg/auth
+
+  auth-provider-tests:
+    name: Auth Provider Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.24.0'
+          cache: true
+
+      - name: Run auth provider scoped tests
+        run: |
+          NPROC="$(nproc)"
+          go test -short -timeout=2m -p "$NPROC" ./pkg/auth/providers ./pkg/auth/docker
 
   security-tests:
     name: Security Tests
@@ -96,14 +115,15 @@ jobs:
   basic-validation:
     name: Basic Validation
     runs-on: ubuntu-latest
-    needs: [build-validation, config-tests, auth-tests, security-tests]
+    needs: [build-validation, config-tests, auth-core-tests, auth-provider-tests, security-tests]
     if: always()
     steps:
       - name: Enforce required status outcome
         run: |
           if [ "${{ needs.build-validation.result }}" != "success" ] || \
              [ "${{ needs.config-tests.result }}" != "success" ] || \
-             [ "${{ needs.auth-tests.result }}" != "success" ] || \
+             [ "${{ needs.auth-core-tests.result }}" != "success" ] || \
+             [ "${{ needs.auth-provider-tests.result }}" != "success" ] || \
              [ "${{ needs.security-tests.result }}" != "success" ]; then
             echo "Basic Validation: FAIL"
             exit 1

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -106,3 +106,4 @@ Updates are tracked here in append-only format.
 | 2026-02-13T12:31:32+00:00 | chore/pr-validation-remove-redundant-auth-smoke-20260213 | workflows | removed redundant auth provider smoke step from PR gate |
 | 2026-02-13T13:07:40+00:00 | chore/gate-single-context-normalization-20260213 | workflows | normalized required checks to single Basic Validation context |
 | 2026-02-13T13:19:19+00:00 | chore/pr-validation-parallel-blocking-20260213 | workflows | parallelized PR validation jobs under Basic Validation gate |
+| 2026-02-13T14:00:10+00:00 | integrate/mvp | .github/workflows | Sharded auth CI gate into core/providers with single Basic Validation. |


### PR DESCRIPTION
## Summary\n- split auth validation into two parallel jobs: core package and provider/docker packages\n- keep a single required gate by aggregating both jobs in Basic Validation\n- append progress log entry\n\n## Verification\n- go test -short -timeout=2m -p "8" ./pkg/auth/providers ./pkg/auth/docker\n- go test -short -timeout=2m -p "8" ./pkg/config/... ./internal/security/...\n- go test -short -timeout=2m -p "8" ./pkg/auth/... *(current integrate/mvp baseline still fails locally in TestLoadAuthConfigWithCustomPath)*