### PR TITLE
chore(ci): tune reusable go job warm path

### DIFF
--- a/.github/workflows/_go-ci-job.yml
+++ b/.github/workflows/_go-ci-job.yml
@@ -17,6 +17,10 @@ on:
         required: false
         type: boolean
         default: false
+      verify-modules:
+        required: false
+        type: boolean
+        default: false
       go-version:
         required: false
         type: string
@@ -39,9 +43,11 @@ jobs:
 
       - name: Download dependencies
         if: ${{ inputs.prepare-modules }}
-        run: |
-          go mod download
-          go mod verify
+        run: go mod download
+
+      - name: Verify dependencies
+        if: ${{ inputs.prepare-modules && inputs.verify-modules }}
+        run: go mod verify
 
       - name: Run command
         run: ${{ inputs.run-command }}

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -19,7 +19,6 @@ jobs:
     with:
       job-name: Build Validation
       timeout-minutes: 10
-      prepare-modules: true
       run-command: make -f Makefile.ci ci-ultra-fast
 
   config-tests:

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -108,3 +108,4 @@ Updates are tracked here in append-only format.
 | 2026-02-13T13:19:19+00:00 | chore/pr-validation-parallel-blocking-20260213 | workflows | parallelized PR validation jobs under Basic Validation gate |
 | 2026-02-13T14:00:10+00:00 | integrate/mvp | .github/workflows | Sharded auth CI gate into core/providers with single Basic Validation. |
 | 2026-02-13T14:26:59+00:00 | chore/pr-validation-reusable-go-setup-20260213 | .github/workflows | Reused Go CI setup via workflow_call for PR validation shards. |
+| 2026-02-13T14:41:04+00:00 | chore/pr-validation-warmpath-tune-20260213 | .github/workflows | Tuned reusable Go job warm path; skip explicit module prep in PR build job. |


### PR DESCRIPTION
## Summary
- tune reusable Go CI workflow to separate `download` and optional `verify` module steps
- keep module verification optional (`verify-modules`) and disabled by default for PR validation speed path
- remove explicit module-prep from PR build validation shard to rely on setup-go cache warm path

## Verification
- `.github/workflows/verify-consolidation.sh`
- `go test -short -timeout=2m -p "$(nproc)" ./pkg/config/... ./internal/security/...`
- `go test -short -timeout=2m -p "$(nproc)" ./pkg/auth/providers ./pkg/auth/docker`
