### PR TITLE
fix(auth): avoid false positive config path validation

### DIFF
--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -109,3 +109,4 @@ Updates are tracked here in append-only format.
 | 2026-02-13T14:00:10+00:00 | integrate/mvp | .github/workflows | Sharded auth CI gate into core/providers with single Basic Validation. |
 | 2026-02-13T14:26:59+00:00 | chore/pr-validation-reusable-go-setup-20260213 | .github/workflows | Reused Go CI setup via workflow_call for PR validation shards. |
 | 2026-02-13T14:41:04+00:00 | chore/pr-validation-warmpath-tune-20260213 | .github/workflows | Tuned reusable Go job warm path; skip explicit module prep in PR build job. |
+| 2026-02-13T15:09:30+00:00 | chore/auth-config-path-validation-fix-20260213 | pkg/auth | Fix config path guard false-positive on /home/*/dev/* repositories. |

--- a/pkg/auth/config.go
+++ b/pkg/auth/config.go
@@ -1818,12 +1818,16 @@ func validateConfigFilePath(filePath string) error {
 		return fmt.Errorf("hidden files not allowed as config")
 	}
 
-	// SECURITY: Reject special file names.
+	// SECURITY: Reject system pseudo-filesystem paths and sensitive file names.
+	absPathLower := strings.ToLower(absPath)
+	for _, prefix := range []string{"/dev", "/proc", "/sys"} {
+		if absPathLower == prefix || strings.HasPrefix(absPathLower, prefix+string(filepath.Separator)) {
+			return fmt.Errorf("suspicious file path detected")
+		}
+	}
 
-	dangerousNames := []string{"/dev/", "/proc/", "/sys/", "passwd", "shadow", "sudoers"}
-
-	for _, dangerous := range dangerousNames {
-		if strings.Contains(strings.ToLower(absPath), dangerous) {
+	for _, sensitiveName := range []string{"passwd", "shadow", "sudoers"} {
+		if strings.EqualFold(filename, sensitiveName) {
 			return fmt.Errorf("suspicious file path detected")
 		}
 	}


### PR DESCRIPTION
## Summary
- fix `validateConfigFilePath` false positives for repositories located under paths containing `/dev/`
- keep strict blocking for real pseudo-filesystem paths (`/dev`, `/proc`, `/sys`)
- keep sensitive filename rejection (`passwd`, `shadow`, `sudoers`) scoped to actual filename

## Root cause
- prior check used substring matching on absolute paths (`strings.Contains(absPath, "/dev/")`), which incorrectly rejected valid paths like `/home/<user>/dev/<repo>/config/...`

## Verification
- `go test -short -count=1 -timeout=2m -p "$(nproc)" ./pkg/auth -run TestLoadAuthConfigWithCustomPath`
- `go test -short -count=1 -timeout=2m -p "$(nproc)" ./pkg/auth/...`
- `go test -short -count=1 -timeout=2m -p "$(nproc)" ./pkg/config/... ./internal/security/...`
