### PR TITLE
chore(ci): tuneable PR validation guard threshold

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -19,3 +19,4 @@
 - Per-branch concurrency group: `${{ github.ref }}`.
 - Required gate context for protected branches: `Basic Validation`.
 - `Basic Validation` aggregates parallel blocking jobs for build + `pkg/config` + auth core/provider shards + `internal/security`.
+- `pr-validation-performance-guard.yml` supports manual threshold tuning via `workflow_dispatch` input `threshold_seconds` (default `154`).

--- a/.github/workflows/pr-validation-performance-guard.yml
+++ b/.github/workflows/pr-validation-performance-guard.yml
@@ -5,6 +5,11 @@ on:
     workflows: ["PR Validation"]
     types: [completed]
   workflow_dispatch:
+    inputs:
+      threshold_seconds:
+        description: "Override regression threshold in seconds (default 154 = 2m34s)"
+        required: false
+        default: "154"
 
 concurrency:
   group: ${{ github.ref }}
@@ -42,9 +47,14 @@ jobs:
             const owner = context.repo.owner;
             const repo = context.repo.repo;
             const workflowId = process.env.TARGET_WORKFLOW_FILE;
-            const thresholdSeconds = Number(process.env.THRESHOLD_SECONDS);
+            const thresholdSeconds = Number(context.payload.inputs?.threshold_seconds || process.env.THRESHOLD_SECONDS);
             const sampleSize = Number(process.env.SAMPLE_SIZE);
             const minSamples = Number(process.env.MIN_SAMPLES);
+
+            if (!Number.isFinite(thresholdSeconds) || thresholdSeconds <= 0) {
+              core.setFailed(`Invalid threshold_seconds: ${context.payload.inputs?.threshold_seconds || process.env.THRESHOLD_SECONDS}`);
+              return;
+            }
 
             const toSeconds = (start, end) => {
               if (!start || !end) return NaN;

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -113,3 +113,4 @@ Updates are tracked here in append-only format.
 | 2026-02-13T15:19:02+00:00 | chore/pr-validation-performance-guard-20260213 | .github/workflows | Add PR-validation p95 regression guard with automated issue alerts. |
 | 2026-02-13T17:03:27+00:00 | main | docs | Move three root docs into docs subdirectories; update docs links. |
 | 2026-02-13T17:08:25+00:00 | main | root-config | Remove unused .go-build-config.yaml; keep .controller-gen.yaml and .nancy-ignore. |
+| 2026-02-13T18:08:21+00:00 | chore/perf-guard-threshold-input-20260213 | .github/workflows | Add dispatch threshold override for PR Validation Performance Guard. |


### PR DESCRIPTION
## Summary
- add workflow_dispatch input threshold_seconds to PR Validation Performance Guard
- use dispatch input override with fallback default THRESHOLD_SECONDS=154
- fail fast when threshold input is invalid
- document manual threshold override in .github/workflows/README.md

## Validation
- go test -count=1 ./tests -run TestQuickstartDocumentation