### PR TITLE
chore(ci): add sampling controls to performance guard

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -19,4 +19,4 @@
 - Per-branch concurrency group: `${{ github.ref }}`.
 - Required gate context for protected branches: `Basic Validation`.
 - `Basic Validation` aggregates parallel blocking jobs for build + `pkg/config` + auth core/provider shards + `internal/security`.
-- `pr-validation-performance-guard.yml` supports manual threshold tuning via `workflow_dispatch` input `threshold_seconds` (default `154`).
+- `pr-validation-performance-guard.yml` supports manual tuning via `workflow_dispatch` inputs: `threshold_seconds` (default `154`), `sample_size` (default `10`), `min_samples` (default `5`).

--- a/.github/workflows/pr-validation-performance-guard.yml
+++ b/.github/workflows/pr-validation-performance-guard.yml
@@ -10,6 +10,14 @@ on:
         description: "Override regression threshold in seconds (default 154 = 2m34s)"
         required: false
         default: "154"
+      sample_size:
+        description: "Number of recent successful PR Validation runs to analyze (default 10)"
+        required: false
+        default: "10"
+      min_samples:
+        description: "Minimum successful samples required before evaluating alerts (default 5)"
+        required: false
+        default: "5"
 
 concurrency:
   group: ${{ github.ref }}
@@ -48,11 +56,19 @@ jobs:
             const repo = context.repo.repo;
             const workflowId = process.env.TARGET_WORKFLOW_FILE;
             const thresholdSeconds = Number(context.payload.inputs?.threshold_seconds || process.env.THRESHOLD_SECONDS);
-            const sampleSize = Number(process.env.SAMPLE_SIZE);
-            const minSamples = Number(process.env.MIN_SAMPLES);
+            const sampleSize = Number(context.payload.inputs?.sample_size || process.env.SAMPLE_SIZE);
+            const minSamples = Number(context.payload.inputs?.min_samples || process.env.MIN_SAMPLES);
 
             if (!Number.isFinite(thresholdSeconds) || thresholdSeconds <= 0) {
               core.setFailed(`Invalid threshold_seconds: ${context.payload.inputs?.threshold_seconds || process.env.THRESHOLD_SECONDS}`);
+              return;
+            }
+            if (!Number.isInteger(sampleSize) || sampleSize <= 0) {
+              core.setFailed(`Invalid sample_size: ${context.payload.inputs?.sample_size || process.env.SAMPLE_SIZE}`);
+              return;
+            }
+            if (!Number.isInteger(minSamples) || minSamples <= 0 || minSamples > sampleSize) {
+              core.setFailed(`Invalid min_samples: ${context.payload.inputs?.min_samples || process.env.MIN_SAMPLES}`);
               return;
             }
 

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -114,3 +114,4 @@ Updates are tracked here in append-only format.
 | 2026-02-13T17:03:27+00:00 | main | docs | Move three root docs into docs subdirectories; update docs links. |
 | 2026-02-13T17:08:25+00:00 | main | root-config | Remove unused .go-build-config.yaml; keep .controller-gen.yaml and .nancy-ignore. |
 | 2026-02-13T18:08:21+00:00 | chore/perf-guard-threshold-input-20260213 | .github/workflows | Add dispatch threshold override for PR Validation Performance Guard. |
+| 2026-02-13T18:17:50+00:00 | chore/perf-guard-sampling-inputs-20260213 | .github/workflows | Add dispatch sample_size/min_samples controls for perf guard. |


### PR DESCRIPTION
## Summary
- add workflow_dispatch inputs sample_size and min_samples to PR Validation Performance Guard
- keep env defaults unchanged and allow manual override at dispatch time
- validate sample_size/min_samples input values before analysis
- document new guard inputs in workflow README

## Validation
- go test -count=1 ./tests -run TestQuickstartDocumentation