### PR TITLE
chore(ci): make markdown link integrity blocking

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -19,5 +19,5 @@
 - Per-branch concurrency group: `${{ github.ref }}`.
 - Required gate context for protected branches: `Basic Validation`.
 - `Basic Validation` aggregates parallel blocking jobs for build + `pkg/config` + auth core/provider shards + `internal/security`.
-- `pr-validation.yml` also runs `Docs Link Integrity (Advisory)` as a non-blocking markdown relative-link scan.
+- `pr-validation.yml` runs `Docs Link Integrity` as a blocking markdown relative-link scan aggregated by `Basic Validation`.
 - `pr-validation-performance-guard.yml` supports manual tuning via `workflow_dispatch` inputs: `threshold_seconds` (default `154`), `sample_size` (default `10`), `min_samples` (default `5`).

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -57,14 +57,14 @@ jobs:
         NPROC="$(nproc)"
         go test -short -timeout=2m -p "$NPROC" ./internal/security/...
 
-  docs-link-integrity-advisory:
-    name: Docs Link Integrity (Advisory)
+  docs-link-integrity:
+    name: Docs Link Integrity
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Scan markdown relative links (advisory)
+      - name: Scan markdown relative links
         run: |
           python3 - <<'PY'
           from pathlib import Path
@@ -95,16 +95,17 @@ jobs:
           if not missing:
               print("No missing relative markdown links found.")
           else:
-              print(f"::warning::Found {len(missing)} missing relative markdown links (advisory, non-blocking).")
+              print(f"::error::Found {len(missing)} missing relative markdown links.")
               counts = Counter(src for src, _ in missing)
               for src, n in counts.most_common(15):
                   print(f"{n:3d} {src}")
+              raise SystemExit(1)
           PY
 
   basic-validation:
     name: Basic Validation
     runs-on: ubuntu-latest
-    needs: [build-validation, config-tests, auth-core-tests, auth-provider-tests, security-tests]
+    needs: [build-validation, config-tests, auth-core-tests, auth-provider-tests, security-tests, docs-link-integrity]
     if: always()
     steps:
       - name: Enforce required status outcome
@@ -113,7 +114,8 @@ jobs:
              [ "${{ needs.config-tests.result }}" != "success" ] || \
              [ "${{ needs.auth-core-tests.result }}" != "success" ] || \
              [ "${{ needs.auth-provider-tests.result }}" != "success" ] || \
-             [ "${{ needs.security-tests.result }}" != "success" ]; then
+             [ "${{ needs.security-tests.result }}" != "success" ] || \
+             [ "${{ needs.docs-link-integrity.result }}" != "success" ]; then
             echo "Basic Validation: FAIL"
             exit 1
           fi

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -120,3 +120,4 @@ Updates are tracked here in append-only format.
 | 2026-02-13T20:05:44+00:00 | chore/docs-link-integrity-pack3-20260213 | docs | Pack3 completed: fixed remaining broken links to zero; docs test green. |
 | 2026-02-13T20:27:50+00:00 | chore/ci-markdown-link-guard-20260213 | .github/workflows | Added advisory markdown link integrity scan to PR validation. |
 | 2026-02-13T20:57:08+00:00 | chore/ci-markdown-link-guard-20260213 | .github/workflows | Fixed advisory link scan workflow parse token for GitHub Actions. |
+| 2026-02-13T21:06:52+00:00 | chore/ci-markdown-link-blocking-20260213 | .github/workflows | Promoted markdown link integrity from advisory to blocking PR gate. |


### PR DESCRIPTION
## Summary
- promote markdown relative-link scan from advisory to blocking in 
- include docs-link-integrity result in  gate aggregation
- update workflow docs for blocking policy

## Validation
- YAML parse:  loads successfully
- local markdown scan baseline: 
- go test -count=1 ./tests -run TestQuickstartDocumentation
