### PR TITLE
chore(ci): add scope-aware PR validation fast lane

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -18,6 +18,7 @@
 - Ubuntu-only runners.
 - Per-branch concurrency group: `${{ github.ref }}`.
 - Required gate context for protected branches: `Basic Validation`.
-- `Basic Validation` aggregates parallel blocking jobs for build + `pkg/config` + auth core/provider shards + `internal/security`.
-- `pr-validation.yml` runs `Docs Link Integrity` as a blocking markdown relative-link scan aggregated by `Basic Validation`.
+- `pr-validation.yml` classifies change scope and runs a fast lane for docs/ci-only PRs.
+- `Basic Validation` remains the single required context and conditionally aggregates full blocking jobs for code changes.
+- `pr-validation.yml` always enforces blocking `Docs Link Integrity` and `Root Allowlist` checks.
 - `pr-validation-performance-guard.yml` supports manual tuning via `workflow_dispatch` inputs: `threshold_seconds` (default `154`), `sample_size` (default `10`), `min_samples` (default `5`).

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -14,7 +14,60 @@ permissions:
   contents: read
 
 jobs:
+  scope-classifier:
+    name: Scope Classifier
+    runs-on: ubuntu-latest
+    outputs:
+      full_gate: ${{ steps.classify.outputs.full_gate }}
+      docs_ci_only: ${{ steps.classify.outputs.docs_ci_only }}
+      changed_count: ${{ steps.classify.outputs.changed_count }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Classify PR change scope
+        id: classify
+        run: |
+          git diff --name-only "${{ github.event.pull_request.base.sha }}" "${{ github.event.pull_request.head.sha }}" > changed_files.txt
+          python3 - <<'PY'
+          import fnmatch
+          import os
+          from pathlib import Path
+
+          files = [line.strip() for line in Path("changed_files.txt").read_text(encoding="utf-8").splitlines() if line.strip()]
+          fast_patterns = [
+              "docs/**",
+              ".github/workflows/**",
+              "ci/**",
+              "README.md",
+              "SECURITY.md",
+              "CONTRIBUTING.md",
+              "CODE_OF_CONDUCT.md",
+              "CHANGELOG.md",
+              "QUICKSTART.md",
+              "mkdocs.yml",
+              "scripts/README.md",
+              "scripts/validate-root-allowlist.sh",
+          ]
+
+          docs_ci_only = bool(files) and all(any(fnmatch.fnmatch(f, p) for p in fast_patterns) for f in files)
+          full_gate = not docs_ci_only
+
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as out:
+              out.write(f"changed_count={len(files)}\n")
+              out.write(f"docs_ci_only={'true' if docs_ci_only else 'false'}\n")
+              out.write(f"full_gate={'true' if full_gate else 'false'}\n")
+
+          print(f"changed_count={len(files)}")
+          print(f"docs_ci_only={docs_ci_only}")
+          print(f"full_gate={full_gate}")
+          PY
+
   build-validation:
+    needs: [scope-classifier]
+    if: needs.scope-classifier.outputs.full_gate == 'true'
     uses: ./.github/workflows/_go-ci-job.yml
     with:
       job-name: Build Validation
@@ -22,6 +75,8 @@ jobs:
       run-command: make -f Makefile.ci ci-ultra-fast
 
   config-tests:
+    needs: [scope-classifier]
+    if: needs.scope-classifier.outputs.full_gate == 'true'
     uses: ./.github/workflows/_go-ci-job.yml
     with:
       job-name: Config Tests
@@ -31,6 +86,8 @@ jobs:
         go test -short -timeout=2m -p "$NPROC" ./pkg/config/...
 
   auth-core-tests:
+    needs: [scope-classifier]
+    if: needs.scope-classifier.outputs.full_gate == 'true'
     uses: ./.github/workflows/_go-ci-job.yml
     with:
       job-name: Auth Core Tests
@@ -40,6 +97,8 @@ jobs:
         go test -short -timeout=2m -p "$NPROC" ./pkg/auth
 
   auth-provider-tests:
+    needs: [scope-classifier]
+    if: needs.scope-classifier.outputs.full_gate == 'true'
     uses: ./.github/workflows/_go-ci-job.yml
     with:
       job-name: Auth Provider Tests
@@ -49,6 +108,8 @@ jobs:
         go test -short -timeout=2m -p "$NPROC" ./pkg/auth/providers ./pkg/auth/docker
 
   security-tests:
+    needs: [scope-classifier]
+    if: needs.scope-classifier.outputs.full_gate == 'true'
     uses: ./.github/workflows/_go-ci-job.yml
     with:
       job-name: Security Tests
@@ -102,21 +163,41 @@ jobs:
               raise SystemExit(1)
           PY
 
+  root-allowlist:
+    name: Root Allowlist
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Validate root allowlist
+        run: ./scripts/validate-root-allowlist.sh
+
   basic-validation:
     name: Basic Validation
     runs-on: ubuntu-latest
-    needs: [build-validation, config-tests, auth-core-tests, auth-provider-tests, security-tests, docs-link-integrity]
+    needs: [scope-classifier, build-validation, config-tests, auth-core-tests, auth-provider-tests, security-tests, docs-link-integrity, root-allowlist]
     if: always()
     steps:
       - name: Enforce required status outcome
         run: |
-          if [ "${{ needs.build-validation.result }}" != "success" ] || \
-             [ "${{ needs.config-tests.result }}" != "success" ] || \
-             [ "${{ needs.auth-core-tests.result }}" != "success" ] || \
-             [ "${{ needs.auth-provider-tests.result }}" != "success" ] || \
-             [ "${{ needs.security-tests.result }}" != "success" ] || \
-             [ "${{ needs.docs-link-integrity.result }}" != "success" ]; then
+          echo "Scope: docs_ci_only=${{ needs.scope-classifier.outputs.docs_ci_only }}, full_gate=${{ needs.scope-classifier.outputs.full_gate }}, changed_count=${{ needs.scope-classifier.outputs.changed_count }}"
+
+          if [ "${{ needs.docs-link-integrity.result }}" != "success" ] || \
+             [ "${{ needs.root-allowlist.result }}" != "success" ]; then
             echo "Basic Validation: FAIL"
             exit 1
           fi
+
+          if [ "${{ needs.scope-classifier.outputs.full_gate }}" = "true" ]; then
+            if [ "${{ needs.build-validation.result }}" != "success" ] || \
+               [ "${{ needs.config-tests.result }}" != "success" ] || \
+               [ "${{ needs.auth-core-tests.result }}" != "success" ] || \
+               [ "${{ needs.auth-provider-tests.result }}" != "success" ] || \
+               [ "${{ needs.security-tests.result }}" != "success" ]; then
+              echo "Basic Validation: FAIL"
+              exit 1
+            fi
+          fi
+
           echo "Basic Validation: PASS"

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -122,3 +122,4 @@ Updates are tracked here in append-only format.
 | 2026-02-13T20:57:08+00:00 | chore/ci-markdown-link-guard-20260213 | .github/workflows | Fixed advisory link scan workflow parse token for GitHub Actions. |
 | 2026-02-13T21:06:52+00:00 | chore/ci-markdown-link-blocking-20260213 | .github/workflows | Promoted markdown link integrity from advisory to blocking PR gate. |
 | 2026-02-13T21:15:35+00:00 | main | root-policy | Added root allowlist validator and Phase 3 candidate registry. |
+| 2026-02-13T21:35:06+00:00 | chore/pr-validation-scope-fastlane-20260213 | .github/workflows | Added scope-aware PR fast lane with conditional full gate. |


### PR DESCRIPTION
## Summary
- add scope-classifier job to classify PRs as docs/ci-only vs full code changes
- run full test shards only when full gate is required
- keep Basic Validation as single required context with conditional aggregation
- enforce Root Allowlist and Docs Link Integrity on every PR

## Validation
- YAML parse: .github/workflows/pr-validation.yml loads successfully
- ./scripts/validate-root-allowlist.sh
- markdown relative-link scan baseline: MISSING_TOTAL=0
- go test -count=1 ./tests -run TestQuickstartDocumentation
